### PR TITLE
disable devices without attached tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
@@ -30,7 +29,6 @@ sourceSets {
 
 repositories {
     mavenLocal()
-    jcenter()
     maven { url 'https://kotlin.bintray.com/ktor' }
 }
 
@@ -40,15 +38,15 @@ dependencies {
     implementation "ch.qos.logback:logback-classic:$logback_version"
     implementation "io.ktor:ktor-server-core:$ktor_version"
     implementation "io.ktor:ktor-auth:$ktor_version"
-    implementation "com.h2database:h2:1.4.200"
-    implementation "org.postgresql:postgresql:42.2.19"
-    implementation "net.logstash.logback:logstash-logback-encoder:6.6"
+    implementation 'com.h2database:h2:2.1.210'
+    implementation 'org.postgresql:postgresql:42.3.1'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'
     implementation "io.ktor:ktor-jackson:$ktor_version"
     implementation "org.jetbrains.exposed:exposed-core:$exposed_version"
     implementation "org.jetbrains.exposed:exposed-dao:$exposed_version"
     implementation "org.jetbrains.exposed:exposed-jdbc:$exposed_version"
     testImplementation "io.ktor:ktor-server-tests:$ktor_version"
-    testImplementation 'com.willowtreeapps.assertk:assertk-jvm:0.23.1'
+    testImplementation 'com.willowtreeapps.assertk:assertk-jvm:0.25'
 }
 
 shadowJar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-ktor_version=1.5.2
+ktor_version=1.6.7
 kotlin.code.style=official
-kotlin_version=1.4.31
-logback_version=1.2.3
-exposed_version=0.29.1
+kotlin_version=1.6.10
+logback_version=1.2.10
+exposed_version=0.37.3

--- a/src/Application.kt
+++ b/src/Application.kt
@@ -50,7 +50,7 @@ val toolService = ToolService(mapper)
 val deviceService = DeviceService(mapper)
 
 @KtorExperimentalAPI
-val authenticationService = AuthenticationService(deviceService)
+val authenticationService = AuthenticationService(deviceService, mapper)
 
 @KtorExperimentalAPI
 @Suppress("unused") // Referenced in application.conf

--- a/src/Application.kt
+++ b/src/Application.kt
@@ -116,7 +116,6 @@ fun Application.module(testAdmin: Boolean = false) {
 
         anyHost()
 
-        allowCredentials = true
         allowNonSimpleContentTypes = true
     }
     install(ForwardedHeaderSupport) // support for reverse proxies

--- a/test/ApiAuthTest.kt
+++ b/test/ApiAuthTest.kt
@@ -9,7 +9,6 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.util.InternalAPI
 import io.ktor.util.KtorExperimentalAPI
 import isOK
-import kotlin.test.assertEquals
 import org.junit.Test
 
 @InternalAPI
@@ -36,7 +35,6 @@ class ApiAuthTest : CommonTest() {
         }.apply {
             // then
             assertThat(response.status()).isOK()
-            assertEquals(HttpStatusCode.OK, response.status())
         }
     }
 

--- a/test/ClientApiV2Test.kt
+++ b/test/ClientApiV2Test.kt
@@ -7,6 +7,7 @@ import assertk.assertions.doesNotContain
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import cloud.fabx.model.IdleState
 import cloud.fabx.model.ToolState
 import cloud.fabx.model.ToolType
@@ -67,6 +68,26 @@ class ClientApiV2Test : CommonTest() {
                             + "${toolDto1.id},0,UNLOCK,4200,IDLE_LOW,New Tool 1\n"
                             + "${toolDto2.id},1,UNLOCK,8910,IDLE_HIGH,New Tool 2\n"
                 )
+        }
+    }
+
+    @Test
+    fun `given no attached tools when getting config then Unauthorized`() = testApp {
+        // given
+        val mac = "aaffeeaaffee"
+        val secret = "newSecret"
+        givenDevice(
+            mac = mac,
+            secret = secret
+        )
+
+        // when
+        handleRequest(HttpMethod.Get, "/clientApi/v1/${mac}/config") {
+            addBasicAuth(mac, secret)
+        }.apply {
+            // then
+            assertThat(response.status()).isEqualTo(HttpStatusCode.Unauthorized)
+            assertThat(response.content).isNull()
         }
     }
 
@@ -133,7 +154,11 @@ class ClientApiV2Test : CommonTest() {
 
         val otherMac = "aabbccddeeff"
         val otherSecret = "otherSecret"
-        givenDevice(mac = otherMac, secret = otherSecret)
+        val otherDevice = givenDevice(mac = otherMac, secret = otherSecret)
+        givenTool(
+            otherDevice.id,
+            qualifications = listOf()
+        )
 
         // when
         handleRequest(HttpMethod.Get, "/clientApi/v2/${mac}/config") {
@@ -383,6 +408,28 @@ class ClientApiV2Test : CommonTest() {
         handleRequest(
             HttpMethod.Get,
             "/clientApi/v2/${mac}/permissions/${invalidCardUid}/${invalidCardSecret}"
+        ).apply {
+            // then
+            assertThat(response.status()).isEqualTo(HttpStatusCode.Unauthorized)
+        }
+    }
+
+    @Test
+    fun `given no attached tools when getting permissions then Unauthorized`() = testApp {
+        // given
+        val userDto = givenUser()
+
+        val mac = "aaffeeaaffee"
+        val secret = "newSecret"
+        givenDevice(
+            mac = mac,
+            secret = secret
+        )
+
+        // when
+        handleRequest(
+            HttpMethod.Get,
+            "/clientApi/v1/${mac}/permissions/${userDto.cardId}/${userDto.cardSecret}"
         ).apply {
             // then
             assertThat(response.status()).isEqualTo(HttpStatusCode.Unauthorized)

--- a/test/DeviceTest.kt
+++ b/test/DeviceTest.kt
@@ -239,7 +239,7 @@ class DeviceTest : CommonTest() {
                 .isNotSuccess()
             assertThat(response.content)
                 .isNotNull()
-                .contains("FK_TOOLS_DEVICE_ID")
+                .contains("FK_TOOLS_DEVICE__ID")
         }
     }
 

--- a/test/QualificationTest.kt
+++ b/test/QualificationTest.kt
@@ -381,7 +381,7 @@ class QualificationTest : CommonTest() {
                 .isNotSuccess()
             assertThat(response.content)
                 .isNotNull()
-                .contains("FK_TOOLQUALIFICATIONS_QUALIFICATION_ID")
+                .contains("FK_TOOLQUALIFICATIONS_QUALIFICATION__ID")
         }
     }
 
@@ -400,7 +400,7 @@ class QualificationTest : CommonTest() {
                 .isNotSuccess()
             assertThat(response.content)
                 .isNotNull()
-                .contains("FK_USERQUALIFICATIONS_QUALIFICATION_ID")
+                .contains("FK_USERQUALIFICATIONS_QUALIFICATION__ID")
         }
     }
 }

--- a/test/ToolTest.kt
+++ b/test/ToolTest.kt
@@ -318,7 +318,7 @@ class ToolTest : CommonTest() {
                 .isNotSuccess()
             assertThat(response.content)
                 .isNotNull()
-                .contains("FK_TOOLQUALIFICATIONS_TOOL_ID")
+                .contains("FK_TOOLQUALIFICATIONS_TOOL__ID")
         }
     }
 

--- a/test/UserTest.kt
+++ b/test/UserTest.kt
@@ -391,7 +391,7 @@ class UserTest : CommonTest() {
                 .isNotSuccess()
             assertThat(response.content)
                 .isNotNull()
-                .contains("FK_USERQUALIFICATIONS_USER_ID")
+                .contains("FK_USERQUALIFICATIONS_USER__ID")
         }
     }
 


### PR DESCRIPTION
Requires a device to have at least one attached tool for it to be able to authenticate.

Trade-off: a newly registered device can get its config once at registration time. If it then reboots, it cannot get its config again until at least one tool is attached. I assume this is fine for now.